### PR TITLE
workaround for jruby / nokogiri-java

### DIFF
--- a/lib/rubyvis/scene/svg_scene.rb
+++ b/lib/rubyvis/scene/svg_scene.rb
@@ -38,7 +38,7 @@ module Nokogiri
     end
   end
   def get_element(i)
-    elements[i-1]
+    elements.empty? ? nil : elements[i-1]
   end
   #private :elements
   #private :attributes


### PR DESCRIPTION
fails with exception when accessing element in empty node set it seems.
