### PR TITLE
tag_name should be name. There's no tag_name element in Nokogiri::XML::E...

### DIFF
--- a/lib/rubyvis/scene/svg_scene.rb
+++ b/lib/rubyvis/scene/svg_scene.rb
@@ -150,7 +150,7 @@ module Rubyvis
     
     def self.title(e,s)
       a = e.parent
-      a=nil if (a and (a.tag_name != "a"))
+      a=nil if (a and (a.name != "a"))
       if (s.title) 
         if (!a) 
           a = self.create("a")


### PR DESCRIPTION
This fixes an error when trying to parse the crimea_line.rb example (among others).

rake spec: all tests pass.
