### PR TITLE
Add view_box attribute to SceneElement, and set it on the root SVG element.

### DIFF
--- a/lib/rubyvis/mark/panel.rb
+++ b/lib/rubyvis/mark/panel.rb
@@ -9,7 +9,7 @@ module Rubyvis
     end
 
     @properties=Bar.properties.dup
-    attr_accessor_dsl :transform, :overflow, :canvas
+    attr_accessor_dsl :transform, :overflow, :canvas, :view_box
     attr_accessor :children, :root
     def initialize
       @children=[]

--- a/lib/rubyvis/scene/svg_panel.rb
+++ b/lib/rubyvis/scene/svg_panel.rb
@@ -44,6 +44,9 @@ module Rubyvis
               'width'=>s.width+s.left+s.right,
               'height'=>s.height+s.top+s.bottom
           })
+          if not s.view_box.nil?
+            g.set_attribute('viewBox', s.view_box)
+          end
           #g.attributes['width']=s.width+s.left+s.right
           #g.attributes['height']=s.height+s.top+s.bottom
         end

--- a/lib/rubyvis/sceneelement.rb
+++ b/lib/rubyvis/sceneelement.rb
@@ -101,6 +101,7 @@ module Rubyvis
     attr_accessor :type
     attr_accessor :url
     attr_accessor :width
+    attr_accessor :view_box
     
     def []=(v,i)
       if v.is_a? Numeric

--- a/spec/layout_arc_spec.rb
+++ b/spec/layout_arc_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Arc do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :directed, :events, :fill_style, :height, :id, :left, :line_width, :links, :nodes, :orient, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :directed, :events, :fill_style, :height, :id, :left, :line_width, :links, :nodes, :orient, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Arc.properties.should==props 
   end
   it "should be called using Rubyvis.Layout.Arc" do

--- a/spec/layout_cluster_spec.rb
+++ b/spec/layout_cluster_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Cluster do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style,:group,  :height, :id, :inner_radius, :left, :line_width, :links,  :nodes,   :orient, :outer_radius, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style,:group,  :height, :id, :inner_radius, :left, :line_width, :links,  :nodes,   :orient, :outer_radius, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Cluster.properties.should==props 
   end
   it "should be called using Rubyvis.Layout.Cluster" do

--- a/spec/layout_grid_spec.rb
+++ b/spec/layout_grid_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Grid do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cols, :cursor, :data, :events, :fill_style, :height,  :id, :left, :line_width, :overflow, :reverse, :right, :rows, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cols, :cursor, :data, :events, :fill_style, :height,  :id, :left, :line_width, :overflow, :reverse, :right, :rows, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Grid.properties.should==props
   end
   it "Rubyvis.Layout.Grid be the same as Rubyvis::Layout::Grid" do

--- a/spec/layout_horizon_spec.rb
+++ b/spec/layout_horizon_spec.rb
@@ -3,7 +3,7 @@ describe Rubyvis::Layout::Horizon do
   include Rubyvis::LayoutSpec
   
   it "should have correct properties" do
-    props=[:antialias, :background_style, :bands,  :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :mode, :negative_style, :overflow, :positive_style, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :background_style, :bands,  :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :mode, :negative_style, :overflow, :positive_style, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Horizon.properties.should==props 
   end
   it "should be called using Rubyvis.Layout.Horizon" do

--- a/spec/layout_indent_spec.rb
+++ b/spec/layout_indent_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Indent do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :breadth, :canvas, :cursor, :data, :depth, :events, :fill_style, :height, :id, :left, :line_width, :links,  :nodes,  :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :breadth, :canvas, :cursor, :data, :depth, :events, :fill_style, :height, :id, :left, :line_width, :links,  :nodes,  :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Indent.properties.should==props 
   end
   it "should be called using Rubyvis.Layout.Indent" do

--- a/spec/layout_matrix_spec.rb
+++ b/spec/layout_matrix_spec.rb
@@ -3,7 +3,7 @@ describe Rubyvis::Layout::Matrix do
   include Rubyvis::LayoutSpec
   
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :directed, :events, :fill_style, :height, :id, :left, :line_width, :links, :nodes, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :directed, :events, :fill_style, :height, :id, :left, :line_width, :links, :nodes, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Matrix.properties.should==props 
   end
   describe "rendered" do

--- a/spec/layout_pack_spec.rb
+++ b/spec/layout_pack_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Pack do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links,  :nodes,  :order, :overflow, :reverse, :right, :spacing, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links,  :nodes,  :order, :overflow, :reverse, :right, :spacing, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Pack.properties.should==props 
   end
   describe "rendered" do

--- a/spec/layout_partition_spec.rb
+++ b/spec/layout_partition_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Partition do
   include Rubyvis::LayoutSpec
   it "subclass Fill should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :inner_radius, :left, :line_width, :links,  :nodes,  :order, :orient, :outer_radius, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :inner_radius, :left, :line_width, :links,  :nodes,  :order, :orient, :outer_radius, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Partition::Fill.properties.should==props 
   end
   it "should be called using Rubyvis.Layout.Partition" do

--- a/spec/layout_stack_spec.rb
+++ b/spec/layout_stack_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Stack do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :layers, :left, :line_width, :offset, :order, :orient, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :layers, :left, :line_width, :offset, :order, :orient, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Stack.properties.should==props
   end
   it "Rubyvis.Dot be the same as Rubyvis::Dot" do

--- a/spec/layout_tree_spec.rb
+++ b/spec/layout_tree_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Treemap do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links, :mode, :nodes, :order, :overflow, :padding_bottom, :padding_left, :padding_right, :padding_top, :reverse, :right, :round, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links, :mode, :nodes, :order, :overflow, :padding_bottom, :padding_left, :padding_right, :padding_top, :reverse, :right, :round, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Treemap.properties.should==props 
   end
   describe "rendered" do

--- a/spec/layout_treemap_spec.rb
+++ b/spec/layout_treemap_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 describe Rubyvis::Layout::Treemap do
   include Rubyvis::LayoutSpec
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links, :mode, :nodes, :order, :overflow, :padding_bottom, :padding_left, :padding_right, :padding_top, :reverse, :right, :round, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :links, :mode, :nodes, :order, :overflow, :padding_bottom, :padding_left, :padding_right, :padding_top, :reverse, :right, :round, :stroke_style, :title, :top, :transform, :visible, :view_box, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Layout::Treemap.properties.should==props 
   end
   describe "rendered" do

--- a/spec/panel_spec.rb
+++ b/spec/panel_spec.rb
@@ -3,10 +3,10 @@ describe Rubyvis::Panel do
   before do
     @h=200
     @w=200
-    @vis = Rubyvis.Panel.new.width(@w).height(@h)
+    @vis = Rubyvis.Panel.new.width(@w).height(@h).view_box("0 0 #{@w} #{@h}")
   end
   it "should have correct properties" do
-    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
+    props=[:antialias, :bottom, :canvas, :cursor, :data, :events, :fill_style, :height, :id, :left, :line_width, :overflow, :reverse, :right, :stroke_style, :title, :top, :transform, :view_box, :visible, :width].inject({}) {|ac, v| ac[v]=true; ac}
     Rubyvis::Panel.properties.should==props
   end
   it "should have correct defaults" do
@@ -18,18 +18,18 @@ describe Rubyvis::Panel do
   it "should return valid svg" do   
     @vis.render
     doc=Nokogiri::XML(@vis.to_svg)
-    doc.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"200.0", "height"=>"200.0"})
+    doc.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"200.0", "height"=>"200.0", "viewBox" => "0 0 200 200"})
   end
   it "should allow multiple panel definitions" do
-    vis2 = Rubyvis.Panel.new.width(@w+100).height(@h+100)
+    vis2 = Rubyvis.Panel.new.width(@w+100).height(@h+100).view_box("0 0 #{@w+100} #{@h+100}")
     @vis.render
     vis2.render
     doc1=Nokogiri::XML(@vis.to_svg)
     doc2=Nokogiri::XML(vis2.to_svg)
 
-    doc1.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"200.0", "height"=>"200.0"})
+    doc1.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"200.0", "height"=>"200.0", "viewBox" => "0 0 200 200"})
     
-    doc2.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"300.0", "height"=>"300.0"})
+    doc2.at_xpath("//xmlns:svg").should have_svg_attributes({"font-size"=>"10px", "font-family"=>"sans-serif", "fill"=>"none", "stroke"=>"none", "stroke-width"=>"1.5", "width"=>"300.0", "height"=>"300.0", "viewBox" => "0 0 300 300"})
     
   end
 end


### PR DESCRIPTION
IE doesn't like SVGs without a viewBox attribute, so I've found it necessary to add one in my generated SVGs. This pull request makes it so you can set a view_box attribute on a RubyVis::Panel, and have it automatically reflected in the root <svg> element.
